### PR TITLE
Solveivp alts

### DIFF
--- a/main.py
+++ b/main.py
@@ -40,16 +40,31 @@ if on_hpg:
     out_fname = sys.argv[2]
 
 else:
-    init_dir = r"trts_inputs"
-    out_dir = r"trts_outputs"
-
+    #init_dir = r"trts_inputs"
+    #out_dir = r"trts_outputs"
+    init_dir = r"bay_inputs"
+    out_dir = r"bay_outputs"
     #init_fname = "mocktrts_cdte_800nm_input.csv"
     #exp_fname = "mocktrts_cdte_800nm.csv"
     #exp_fname = "abrupt_p0.csv"
-    init_fname = "2A1FSGS_input.csv"
-    exp_fname = "2A1FSGS.csv"
-    out_fnames = {2:"ODEINT",
-                  3:"SOLVEIVP"}
+    #init_fname = "2A1FSGS_input.csv"
+    #exp_fname = "2A1FSGS.csv"
+    init_fnames = {0:"2A1FSGS_TRPL_input.csv",
+                   1:"3B1FSGS_TRPL_input.csv",
+                   2:"staub_MAPI_threepower_twothick_input.csv",
+                   3:"staub_MAPI_power_input.csv"}
+    init_fname = init_fnames[jobid]
+
+    exp_fnames = {0:"2A1FSGS_TRPL.csv",
+                  1:"3B1FSGS_TRPL.csv",
+                  2:"staub_MAPI_threepower_twothick_withauger.csv",
+                  3:"real_staub_aug_corr.csv"}
+    exp_fname = exp_fnames[jobid]
+
+    out_fnames = {0:"2A1FSGS_TRPL",
+                  1:"3B1FSGS_TRPL",
+                  2:"FINAL_2T",
+                  3:"FINAL_REAL"}
     out_fname = out_fnames[jobid]
 
 init_pathname = os.path.join(init_dir, init_fname)
@@ -107,7 +122,7 @@ if __name__ == "__main__":
     logger, handler = start_logging(log_dir=os.path.join(out_pathname))
     # Set space and time grid options
     #Length = [311,2000,311,2000, 311, 2000]
-    Length  = 3000                            # Length (nm)
+    Length  = 311                           # Length (nm)
     L   = 128                                # Spatial points
     plT = 1                                  # Set PL interval (dt)
     pT  = (0,1,3,10,30,100)                   # Set plot intervals (%)
@@ -131,17 +146,17 @@ if __name__ == "__main__":
               "m":0}
 
     initial_guesses = {"n0":1e8,
-                        "p0": 1e13,
-                        "mu_n": 320,
-                        "mu_p": 80,
-                        "ks": 2e-10,
-                        "Cn": 1e-99,
-                        "Cp": 1e-99,
-                        "Sf":10000,
-                        "Sb": 1000,
-                        "tauN": 10,
-                        "tauP": 10,
-                        "eps":9.4,
+                        "p0": 1e15,
+                        "mu_n": 20,
+                        "mu_p": 20,
+                        "ks": 4.8e-11,
+                        "Cn": 8e-29,
+                        "Cp": 8e-29,
+                        "Sf":10,
+                        "Sb": 10,
+                        "tauN": 511,
+                        "tauP": 871,
+                        "eps":10,
                         "m":0}
     #mods = [{"p0":3e14}, {"p0":3e16}, {"ks":4.8e-12}, {"ks":4.8e-10},
     #        {"mu_n":2}, {"mu_n":200}, {"mu_p":2}, {"mu_p":200},
@@ -152,11 +167,11 @@ if __name__ == "__main__":
 
     active_params = {"n0":0,
                      "p0":1,
-                     "mu_n":1,
-                     "mu_p":1,
+                     "mu_n":0,
+                     "mu_p":0,
                      "ks":1,
-                     "Cn":0,
-                     "Cp":0,
+                     "Cn":1,
+                     "Cp":1,
                      "Sf":1,
                      "Sb":1,
                      "tauN":1,
@@ -190,7 +205,7 @@ if __name__ == "__main__":
                      "eps":0,
                      "m":0}
 
-    initial_variance = 1e-1
+    initial_variance = 1e-2
 
     param_info = {"names":param_names,
                   "active":active_params,
@@ -202,12 +217,12 @@ if __name__ == "__main__":
                 "noise_level":None}
 
     # TODO: Validation
-    sim_flags = {"num_iters": 100,
-                 "use_numba": True,
-                 "solver":("odeint" if jobid==2 else "solveivp"),
+    sim_flags = {"measurement":"TRPL",
+                 "num_iters": 100000,
+                 "solver": "solveivp",
                  "use_multi_cpus":False,
-                 "rtol":1e-10,
-                 "atol":1e-14,
+                 "rtol":1e-7,
+                 "atol":1e-10,
                  "hmax":4,
                  "anneal_mode": None, # None, "exp", "log"
                  "anneal_params": [1/2500*100, 1e3, 1/2500*0.1], # [Initial T; time constant (exp decreases by 63% when t=, log decreases by 50% when 2t=; minT]
@@ -216,7 +231,7 @@ if __name__ == "__main__":
                  "override_equal_mu":False,
                  "override_equal_s":False,
                  "log_pl":True,
-                 "self_normalize":True,
+                 "self_normalize":False,
                  #"num_initial_guesses":4,
                  "proposal_function":"box", # box or gauss; anything else disables new proposals
                  #"adaptive_covariance":"None", #AM for Harrio Adaptive, LAP for Shaby Log-Adaptive
@@ -224,7 +239,7 @@ if __name__ == "__main__":
                  "one_param_at_a_time":False,
                  #"LAP_params":(1,0.8,0.234),
                  "checkpoint_dirname": os.path.join(out_pathname, "Checkpoints"),
-                 "checkpoint_freq":2500, # Save a checkpoint every #this many iterations#
+                 "checkpoint_freq":25000, # Save a checkpoint every #this many iterations#
                  "load_checkpoint": None,
                  }
 


### PR DESCRIPTION
Exploring faster alternatives to solve_ivp, of which profiling shows significant overhead when using implicit solvers. These alternatives included lighter-weight LSODA wrappers and Julia bindings. Of these, only odeint() showed any significant improvement, but odeint() struggled to converge when rtol was smaller than 1e-6.

Therefore solve_ivp will continue to be the primary solver while odeint is kept as a potential alternative for simulations with more lenient tolerance requirements.