### PR TITLE
Changes to fittables

### DIFF
--- a/GUI/secondary_parameters.py
+++ b/GUI/secondary_parameters.py
@@ -34,7 +34,7 @@ class SecondaryParameters():
                      "epsilon": (self.epsilon, ("lambda",)),
                      "tauC": (self.tauC, ("kC", "Nt")),
                      "Rc-Re": (self.trap_rate, ("kC", "Nt", "tauE")),
-                     "Rc_Rsrh": (self.n_removal_rate, ("tauN", "tauP", "Sf", "Sb", "thickness", "mu_n", "mu_p", "kC", "Nt", "tauE"))}
+                     "Rc-Rsrh": (self.n_removal_rate, ("tauN", "tauP", "Sf", "Sb", "thickness", "mu_n", "mu_p", "kC", "Nt", "tauE"))}
 
         # Most recent thickness used to calculate; determines if recalculation needed when thickness updated
         self.last_thickness = {name: -1 for name in self.func if "thickness" in self.func[name][1]}

--- a/GUI/secondary_parameters.py
+++ b/GUI/secondary_parameters.py
@@ -34,7 +34,7 @@ class SecondaryParameters():
                      "epsilon": (self.epsilon, ("lambda",)),
                      "tauC": (self.tauC, ("kC", "Nt")),
                      "Rc-Re": (self.trap_rate, ("kC", "Nt", "tauE")),
-                     "Rc-Rsrh": (self.n_removal_rate, ("tauN", "tauP", "Sf", "Sb", "thickness", "mu_n", "mu_p", "kC", "Nt", "tauE"))}
+                     "Rc+Rsrh": (self.n_removal_rate, ("tauN", "tauP", "Sf", "Sb", "thickness", "mu_n", "mu_p", "kC", "Nt", "tauE"))}
 
         # Most recent thickness used to calculate; determines if recalculation needed when thickness updated
         self.last_thickness = {name: -1 for name in self.func if "thickness" in self.func[name][1]}
@@ -126,11 +126,11 @@ class SecondaryParameters():
     
     def tauC(self, p):
         """Maximum low-occupation capture time, in ns"""
-        return 1 / (p["Nt"] * p["kC"]) * 1e-9
+        return 1 / (p["Nt"] * p["kC"]) * 1e9
     
     def trap_rate(self, p):
         """Trap 'rate', in s^-1 """
-        return p["kC"] * p['Nt'] - (1 / p["tauE"]) * 1e9
+        return p["kC"] * p['Nt'] - (1 / p["tauE"] * 1e9)
     
     def n_removal_rate(self, p):
-        return (1 / self.hi_tau_srh(p)) * 1e9 + p["kC"] * p['Nt']
+        return (1 / self.hi_tau_srh(p) * 1e9) + p["kC"] * p['Nt']

--- a/Tests/test_bayes_io.py
+++ b/Tests/test_bayes_io.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 import os
-from bayes_io import get_initpoints, get_data, insert_scale_factors, insert_param
+from bayes_io import get_initpoints, get_data, insert_param
 
 class TestUtils(unittest.TestCase):
 
@@ -20,96 +20,6 @@ class TestUtils(unittest.TestCase):
         expected = np.array([[1, 2, 3, 4, 5]], dtype=float)
         np.testing.assert_equal(expected, ic)
         return
-    
-    def test_insert_scale_factors(self):
-        # General test case with multiple measurements; mix of measurement types,
-        # only necessary settings defined.
-        num_meas = 6
-        grid = {"meas_types": ["TRPL"] * 3 + ["TRTS"] * 3,
-                "num_meas": num_meas}
-        
-        param_info = {"names": [],
-                      "active": {},
-                      "unit_conversions": {},
-                      "do_log": {},
-                      "prior_dist": {},
-                      "init_guess": {},
-                      "init_variance": {}}
-        
-        meas_fields = {"select_obs_sets": None}
-
-        # 1. No scale_factor - no change to param_info
-        MCMC_fields = {"self_normalize": None,
-                       "scale_factor": None,
-                       }
-
-        insert_scale_factors(grid, param_info, meas_fields, MCMC_fields)
-
-        for k in param_info:
-            self.assertEqual(len(param_info[k]), 0)
-
-        # 2. Global scale_factor - _s parameter added with desired guess and variance
-        param_info = {"names": [],
-                      "active": {},
-                      "unit_conversions": {},
-                      "do_log": {},
-                      "prior_dist": {},
-                      "init_guess": {},
-                      "init_variance": {}}
-        init_guess = 1
-        init_var = 0.1
-        MCMC_fields["scale_factor"] = ("global", init_guess, init_var) # type: ignore
-
-        insert_scale_factors(grid, param_info, meas_fields, MCMC_fields)
-
-        self.assertTrue("_s" in param_info["names"])
-        self.assertEqual(param_info["active"]["_s"], 1)
-        self.assertEqual(param_info["do_log"]["_s"], 1)
-        self.assertEqual(param_info["prior_dist"]["_s"], (-np.inf, np.inf))
-        self.assertEqual(param_info["init_guess"]["_s"], init_guess)
-        self.assertEqual(param_info["init_variance"]["_s"], init_var)
-
-        # 3. Independent scale_factors - one _s per num_meas
-        param_info = {"names": [],
-                      "active": {},
-                      "unit_conversions": {},
-                      "do_log": {},
-                      "prior_dist": {},
-                      "init_guess": {},
-                      "init_variance": {}}
-        MCMC_fields["scale_factor"] = ("ind", init_guess, init_var) # type: ignore
-
-        insert_scale_factors(grid, param_info, meas_fields, MCMC_fields)
-
-        for i in range(num_meas):
-            self.assertTrue(f"_s{i}" in param_info["names"])
-            self.assertEqual(param_info["active"][f"_s{i}"], 1)
-            self.assertEqual(param_info["do_log"][f"_s{i}"], 1)
-            self.assertEqual(param_info["prior_dist"][f"_s{i}"], (-np.inf, np.inf))
-            self.assertEqual(param_info["init_guess"][f"_s{i}"], init_guess)
-            self.assertEqual(param_info["init_variance"][f"_s{i}"], init_var)
-
-        # 4. If select_obs_sets limits the number of measurements considered, only one _s for each active measurement
-        param_info = {"names": [],
-                      "active": {},
-                      "unit_conversions": {},
-                      "do_log": {},
-                      "prior_dist": {},
-                      "init_guess": {},
-                      "init_variance": {}}
-        meas_fields = {"select_obs_sets": [0, 4, 5]}
-
-        insert_scale_factors(grid, param_info, meas_fields, MCMC_fields)
-
-        for i in range(len(meas_fields["select_obs_sets"])):
-            self.assertTrue(f"_s{i}" in param_info["names"])
-            self.assertEqual(param_info["active"][f"_s{i}"], 1)
-            self.assertEqual(param_info["do_log"][f"_s{i}"], 1)
-            self.assertEqual(param_info["prior_dist"][f"_s{i}"], (-np.inf, np.inf))
-            self.assertEqual(param_info["init_guess"][f"_s{i}"], init_guess)
-            self.assertEqual(param_info["init_variance"][f"_s{i}"], init_var)
-
-        self.assertFalse(f"_s{len(meas_fields['select_obs_sets'])}" in param_info["names"])
 
     def test_insert_fluences(self):
         # Let's assume there are six measurements after select_obs_sets was applied
@@ -246,6 +156,27 @@ class TestUtils(unittest.TestCase):
         for i in expected_ffs:
             self.assertTrue(f"_a{i}" in param_info["names"])
             self.assertEqual(param_info["init_guess"][f"_a{i}"], alphas[i])
+
+    def test_insert_scale_factors(self):
+        # Three constraint grp
+        # Should function the same as insert_fluences, but params are _s instead of _f
+        num_meas = 6
+        param_info = {"names": [],
+                      "active": {},
+                      "unit_conversions": {},
+                      "do_log": {},
+                      "prior_dist": {},
+                      "init_guess": {},
+                      "init_variance": {}}
+        
+        meas_fields = {"scale_factor": (0.02, [0, 1, 2, 3, 4, 5], [(0, 2), (1, 4), (3, 5)])}
+        expected_ffs = [0, 1, 3]
+        scale_fs = np.random.random(size=num_meas)
+        insert_param(param_info, meas_fields, scale_fs, mode="scale_f")
+
+        for i in expected_ffs:
+            self.assertTrue(f"_s{i}" in param_info["names"])
+            self.assertEqual(param_info["init_guess"][f"_s{i}"], scale_fs[i])
 
     def test_get_data_basic(self):
         # Basic selection and cutting operations on dataset

--- a/Tests/test_bayes_io.py
+++ b/Tests/test_bayes_io.py
@@ -34,11 +34,11 @@ class TestUtils(unittest.TestCase):
                       "prior_dist": {},
                       "init_guess": {},
                       "init_variance": {}}
-        
-        meas_fields = {"fittable_fluences": (0.02, [0, 1, 2, 3, 4, 5], None)}
-        expected_ffs = [0, 1, 2, 3, 4, 5]
         fluences = np.random.random(size=num_meas)
-        insert_param(param_info, meas_fields, fluences)
+        meas_fields = {"fittable_fluences": (0.02, [0, 1, 2, 3, 4, 5], None, fluences)}
+        expected_ffs = [0, 1, 2, 3, 4, 5]
+        
+        insert_param(param_info, meas_fields)
 
         for i in expected_ffs:
             self.assertTrue(f"_f{i}" in param_info["names"])
@@ -56,11 +56,10 @@ class TestUtils(unittest.TestCase):
                       "prior_dist": {},
                       "init_guess": {},
                       "init_variance": {}}
-        
-        meas_fields = {"fittable_fluences": (0.02, [0, 1, 2, 3, 4, 5], [])}
-        expected_ffs = [0, 1, 2, 3, 4, 5]
         fluences = np.random.random(size=num_meas)
-        insert_param(param_info, meas_fields, fluences)
+        meas_fields = {"fittable_fluences": (0.02, [0, 1, 2, 3, 4, 5], [], fluences)}
+        expected_ffs = [0, 1, 2, 3, 4, 5]
+        insert_param(param_info, meas_fields)
 
         for i in expected_ffs:
             self.assertTrue(f"_f{i}" in param_info["names"])
@@ -73,11 +72,10 @@ class TestUtils(unittest.TestCase):
                       "prior_dist": {},
                       "init_guess": {},
                       "init_variance": {}}
-        
-        meas_fields = {"fittable_fluences": (0.02, [0, 1, 2, 3, 4, 5], [(1, 2)])}
-        expected_ffs = [0, 1, 3, 4, 5]
         fluences = np.random.random(size=num_meas)
-        insert_param(param_info, meas_fields, fluences)
+        meas_fields = {"fittable_fluences": (0.02, [0, 1, 2, 3, 4, 5], [(1, 2)], fluences)}
+        expected_ffs = [0, 1, 3, 4, 5]
+        insert_param(param_info, meas_fields)
 
         for i in expected_ffs:
             self.assertTrue(f"_f{i}" in param_info["names"])
@@ -90,11 +88,10 @@ class TestUtils(unittest.TestCase):
                       "prior_dist": {},
                       "init_guess": {},
                       "init_variance": {}}
-        
-        meas_fields = {"fittable_fluences": (0.02, [0, 1, 2, 3, 4, 5], [(0, 1, 2, 3, 4, 5)])}
-        expected_ffs = [0]
         fluences = np.random.random(size=num_meas)
-        insert_param(param_info, meas_fields, fluences)
+        meas_fields = {"fittable_fluences": (0.02, [0, 1, 2, 3, 4, 5], [(0, 1, 2, 3, 4, 5)], fluences)}
+        expected_ffs = [0]
+        insert_param(param_info, meas_fields)
 
         for i in expected_ffs:
             self.assertTrue(f"_f{i}" in param_info["names"])
@@ -108,11 +105,10 @@ class TestUtils(unittest.TestCase):
                       "prior_dist": {},
                       "init_guess": {},
                       "init_variance": {}}
-        
-        meas_fields = {"fittable_fluences": (0.02, [0, 1, 2, 3, 4, 5], [(0, 2), (3, 4, 5)])}
-        expected_ffs = [0, 1, 3]
         fluences = np.random.random(size=num_meas)
-        insert_param(param_info, meas_fields, fluences)
+        meas_fields = {"fittable_fluences": (0.02, [0, 1, 2, 3, 4, 5], [(0, 2), (3, 4, 5)], fluences)}
+        expected_ffs = [0, 1, 3]
+        insert_param(param_info, meas_fields)
 
         for i in expected_ffs:
             self.assertTrue(f"_f{i}" in param_info["names"])
@@ -126,11 +122,10 @@ class TestUtils(unittest.TestCase):
                       "prior_dist": {},
                       "init_guess": {},
                       "init_variance": {}}
-        
-        meas_fields = {"fittable_fluences": (0.02, [0, 1, 2, 3, 4, 5], [(0, 2), (1, 4), (3, 5)])}
-        expected_ffs = [0, 1, 3]
         fluences = np.random.random(size=num_meas)
-        insert_param(param_info, meas_fields, fluences)
+        meas_fields = {"fittable_fluences": (0.02, [0, 1, 2, 3, 4, 5], [(0, 2), (1, 4), (3, 5)], fluences)}
+        expected_ffs = [0, 1, 3]
+        insert_param(param_info, meas_fields)
 
         for i in expected_ffs:
             self.assertTrue(f"_f{i}" in param_info["names"])
@@ -147,11 +142,10 @@ class TestUtils(unittest.TestCase):
                       "prior_dist": {},
                       "init_guess": {},
                       "init_variance": {}}
-        
-        meas_fields = {"fittable_absps": (0.02, [0, 1, 2, 3, 4, 5], [(0, 2), (1, 4), (3, 5)])}
-        expected_ffs = [0, 1, 3]
         alphas = np.random.random(size=num_meas)
-        insert_param(param_info, meas_fields, alphas, mode="absorptions")
+        meas_fields = {"fittable_absps": (0.02, [0, 1, 2, 3, 4, 5], [(0, 2), (1, 4), (3, 5)], alphas)}
+        expected_ffs = [0, 1, 3]
+        insert_param(param_info, meas_fields, mode="absorptions")
 
         for i in expected_ffs:
             self.assertTrue(f"_a{i}" in param_info["names"])
@@ -168,11 +162,10 @@ class TestUtils(unittest.TestCase):
                       "prior_dist": {},
                       "init_guess": {},
                       "init_variance": {}}
-        
-        meas_fields = {"scale_factor": (0.02, [0, 1, 2, 3, 4, 5], [(0, 2), (1, 4), (3, 5)])}
-        expected_ffs = [0, 1, 3]
         scale_fs = np.random.random(size=num_meas)
-        insert_param(param_info, meas_fields, scale_fs, mode="scale_f")
+        meas_fields = {"scale_factor": (0.02, [0, 1, 2, 3, 4, 5], [(0, 2), (1, 4), (3, 5)], scale_fs)}
+        expected_ffs = [0, 1, 3]
+        insert_param(param_info, meas_fields, mode="scale_f")
 
         for i in expected_ffs:
             self.assertTrue(f"_s{i}" in param_info["names"])

--- a/Tests/test_metropolis.py
+++ b/Tests/test_metropolis.py
@@ -965,32 +965,23 @@ class TestUtils(unittest.TestCase):
         sim_flags = {"current_sigma": 1,
                      "hmax": 4, "rtol": 1e-5, "atol": 1e-8,
                      "self_normalize": None,
-                     "scale_factor": ("global", 1e-17, 0),
+                     "scale_factor": (0.02, [0, 1, 2, 3, 4, 5], [(0, 2, 4), (1, 3, 5)]),
                      "solver": ("solveivp",),
                      "model": "std"}
 
         p = Parameters(param_info)
-        setattr(p, "_s", 2e-17 ** -1) # PL = thickness * ks * iniPar**2
-
+        # By setting individual scale factors in this simple case the likelihood can be made perfect
+        setattr(p, "_s0", 2e-17 ** -1)
+        setattr(p, "_s1", 2e-15 ** -1)
         nt = 1000
         running_hmax = [4] * len(iniPar)
         times = [np.linspace(0, 100, nt+1), np.linspace(0, 100, nt+1)]
         vals = [np.ones(nt+1) * 23, np.ones(nt+1) * 23]
         uncs = [np.ones(nt+1) * 1e-99, np.ones(nt+1) * 1e-99]
-        accepted = run_iteration(p, simPar, iniPar, times, vals, uncs, None,
-                                 running_hmax, sim_flags, verbose=True,
-                                 logger=self.logger, prev_p=None)
-
-        np.testing.assert_almost_equal(
-            p.likelihood, [0, -4004], decimal=0)  # rtol=1e-5
         
-        # By setting individual scale factors the likelihood can be made perfect
-        sim_flags["scale_factor"] = ("ind", 1e-17, 0)
-        setattr(p, "_s0", 2e-17 ** -1)
-        setattr(p, "_s1", 2e-15 ** -1)
-        accepted = run_iteration(p, simPar, iniPar, times, vals, uncs, None,
-                                 running_hmax, sim_flags, verbose=True,
-                                 logger=self.logger, prev_p=None)
+        run_iteration(p, simPar, iniPar, times, vals, uncs, None,
+                      running_hmax, sim_flags, verbose=True,
+                      logger=self.logger, prev_p=None)
 
         np.testing.assert_almost_equal(
             p.likelihood, [0, 0], decimal=0)  # rtol=1e-5

--- a/Tests/test_sim_utils_Parameters.py
+++ b/Tests/test_sim_utils_Parameters.py
@@ -100,38 +100,19 @@ class TestUtils(unittest.TestCase):
     def test_suppress_scale_factor(self):
         self.testP = Parameters(self.dummy_param_info)
 
-        self.testP._s = 1000
         self.testP._s0 = 1000
         self.testP._s1 = 1000
 
         self.testP.suppress_scale_factor(None, 0)
-        self.assertEqual(self.testP._s, 1000)
         self.assertEqual(self.testP._s0, 1000)
         self.assertEqual(self.testP._s1, 1000)
 
-        self.testP.suppress_scale_factor(("global", 1, 1), 0)
-        self.assertEqual(self.testP._s, 1)
-        self.assertEqual(self.testP._s0, 1000)
-        self.assertEqual(self.testP._s1, 1000)
+        scale_factor = [0.02, [0, 1, 2, 3, 4, 5], [(0, 2, 4), (1, 3, 5)]]
 
-        self.testP.suppress_scale_factor(("ind", 1, 1), 0)
-        self.assertEqual(self.testP._s, 1)
+        self.testP.suppress_scale_factor(scale_factor, 0)
         self.assertEqual(self.testP._s0, 1)
         self.assertEqual(self.testP._s1, 1000)
 
-        self.testP.suppress_scale_factor(("ind", 1, 1), 1)
-        self.assertEqual(self.testP._s, 1)
+        self.testP.suppress_scale_factor(scale_factor, 1)
         self.assertEqual(self.testP._s0, 1)
         self.assertEqual(self.testP._s1, 1)
-
-    def test_get_scale_factor(self):
-        self.testP = Parameters(self.dummy_param_info)
-
-        self.testP._s = 10
-        self.testP._s0 = 100
-        self.testP._s1 = 1000
-
-        self.assertEqual(self.testP.get_scale_factor(None, 0), 0)
-        self.assertEqual(self.testP.get_scale_factor(("global", 1, 1), 0), 1)
-        self.assertEqual(self.testP.get_scale_factor(("ind", 1, 1), 0), 2)
-        self.assertEqual(self.testP.get_scale_factor(("ind", 1, 1), 1), 3)

--- a/bayes_io.py
+++ b/bayes_io.py
@@ -533,7 +533,8 @@ def read_config_script_file(path):
         for fi in fittables:
             if MCMC_fields.get(fi, None) is not None:
                 MCMC_fields[fi][1] = remap_fittable_inds(MCMC_fields[fi][1], meas_flags["select_obs_sets"])
-                MCMC_fields[fi][2] = remap_constraint_grps(MCMC_fields[fi][2], meas_flags["select_obs_sets"])
+                if MCMC_fields[fi][2] is not None:
+                    MCMC_fields[fi][2] = remap_constraint_grps(MCMC_fields[fi][2], meas_flags["select_obs_sets"])
 
     return grid, param_info, meas_flags, MCMC_fields
 

--- a/bayes_validate.py
+++ b/bayes_validate.py
@@ -421,23 +421,23 @@ def validate_MCMC_fields(MCMC_fields: dict, num_measurements: int,
     
     if "scale_factor" in MCMC_fields:
         scale_f = MCMC_fields["scale_factor"]
-        if scale_f is None:
-            pass
-        else:
-            if not ((isinstance(scale_f, (list, tuple))) and len(scale_f) == 3):
-                raise ValueError("scale_factor invalid - must be None, or a list/tuple of 3 elements")
-            if scale_f[0] not in ["global", "ind"]:
-                raise ValueError("scale_factor first value (scale type) invalid - must be \"global\" or \"ind\"")
-            if not isinstance(scale_f[1], (int, float, np.integer)):
-                raise ValueError("scale_factor second value (initial guess) invalid - must be numeric")
-            if not isinstance(scale_f[2], (int, float, np.integer)) or scale_f[2] < 0:
-                raise ValueError("scale_factor third value (initial variance) invalid - must be nonnegative")
+        success = check_fittable_fluence(scale_f)
+        if not success:
+            raise ValueError("Invalid scale_factor - must be None, or tuple"
+                             "(see printed description when verbose=True)")
 
     if "fittable_fluences" in MCMC_fields:
         ff = MCMC_fields["fittable_fluences"]
         success = check_fittable_fluence(ff)
         if not success:
-            raise ValueError("Invalid fittable_fluence - must be None, or tuple"
+            raise ValueError("Invalid fittable_fluences - must be None, or tuple"
+                             "(see printed description when verbose=True)")
+        
+    if "fittable_absps" in MCMC_fields:
+        ff = MCMC_fields["fittable_absps"]
+        success = check_fittable_fluence(ff)
+        if not success:
+            raise ValueError("Invalid fittable_absps - must be None, or tuple"
                              "(see printed description when verbose=True)")
 
     norm = MCMC_fields["self_normalize"]

--- a/bayes_validate.py
+++ b/bayes_validate.py
@@ -17,7 +17,7 @@ def check_fittable_fluence(ff : None | tuple | list) -> bool:
     if ff is None:
         pass
     elif isinstance(ff, (list, tuple)):
-        if len(ff) != 3:
+        if len(ff) < 3 or len(ff) > 4:
             return False
         if not isinstance(ff[0], (float, int)):
             return False
@@ -25,7 +25,7 @@ def check_fittable_fluence(ff : None | tuple | list) -> bool:
             return False
         if ff[2] is not None and not isinstance(ff[2], (list, tuple)):
             return False
-        
+
         if len(ff[1]) == 0:
             return False
 
@@ -40,6 +40,16 @@ def check_fittable_fluence(ff : None | tuple | list) -> bool:
                 for c in constraint_grp:
                     if not isinstance(c, (int, np.integer)) or c < 0:
                         return False
+
+        if len(ff) == 4:
+            if not isinstance(ff[3], (list, tuple, np.ndarray)):
+                return False
+            if len(ff[3]) == 0:
+                return False
+            
+            for i_guess in ff[3]:
+                if not isinstance(i_guess, (int, np.integer, float)) or i_guess < 0:
+                    return False
     else:
         return False
 

--- a/main.py
+++ b/main.py
@@ -49,14 +49,14 @@ if __name__ == "__main__":
     # (Only if the initial condition supplies fluences instead of the entire profile)
     if MCMC_fields.get("fittable_fluences", None) is not None:
         if len(iniPar[0]) != sim_info["nx"][0]:
-            insert_param(param_info, MCMC_fields, iniPar[:, 0], mode="fluences")
+            insert_param(param_info, MCMC_fields, np.ones_like(iniPar[:, 0]), mode="fluences")
         else:
             logger.warning("No fluences found in Input file - fittable_fluences ignored!")
             MCMC_fields["fittable_fluences"] = None
 
     if MCMC_fields.get("fittable_absps", None) is not None:
         if len(iniPar[0]) != sim_info["nx"][0]:
-            insert_param(param_info, MCMC_fields, iniPar[:, 1], mode="absorptions")
+            insert_param(param_info, MCMC_fields, np.ones_like(iniPar[:, 1]), mode="absorptions")
         else:
             logger.warning("No absorptions found in Input file - fittable_absps ignored!")
             MCMC_fields["fittable_absps"] = None

--- a/main.py
+++ b/main.py
@@ -49,14 +49,14 @@ if __name__ == "__main__":
     # (Only if the initial condition supplies fluences instead of the entire profile)
     if MCMC_fields.get("fittable_fluences", None) is not None:
         if len(iniPar[0]) != sim_info["nx"][0]:
-            insert_param(param_info, MCMC_fields, np.ones_like(iniPar[:, 0]), mode="fluences")
+            insert_param(param_info, MCMC_fields, mode="fluences")
         else:
             logger.warning("No fluences found in Input file - fittable_fluences ignored!")
             MCMC_fields["fittable_fluences"] = None
 
     if MCMC_fields.get("fittable_absps", None) is not None:
         if len(iniPar[0]) != sim_info["nx"][0]:
-            insert_param(param_info, MCMC_fields, np.ones_like(iniPar[:, 1]), mode="absorptions")
+            insert_param(param_info, MCMC_fields, mode="absorptions")
         else:
             logger.warning("No absorptions found in Input file - fittable_absps ignored!")
             MCMC_fields["fittable_absps"] = None

--- a/metropolis.py
+++ b/metropolis.py
@@ -542,16 +542,16 @@ def one_sim_likelihood(p, sim_info, IRF_tables, hmax, MCMC_fields, logger, verbo
     ff = MCMC_fields.get("fittable_fluences", None)
     if (ff is not None and i in ff[1]):
         if ff[2] is not None and len(ff[2]) > 0:
-            iniPar[0] = getattr(p, f"_f{search_c_grps(ff[2], i)}")
+            iniPar[0] *= getattr(p, f"_f{search_c_grps(ff[2], i)}")
         else:
-            iniPar[0] = getattr(p, f"_f{i}")
+            iniPar[0] *= getattr(p, f"_f{i}")
 
     fa = MCMC_fields.get("fittable_absps", None)
     if (fa is not None and i in fa[1]):
         if fa[2] is not None and len(fa[2]) > 0:
-            iniPar[1] = getattr(p, f"_a{search_c_grps(fa[2], i)}")
+            iniPar[1] *= getattr(p, f"_a{search_c_grps(fa[2], i)}")
         else:
-            iniPar[1] = getattr(p, f"_a{i}")
+            iniPar[1] *= getattr(p, f"_a{i}")
 
     tSteps, sol, success = converge_simulation(i, p, sim_info, iniPar, times, vals,
                                                hmax, MCMC_fields, logger, verbose)
@@ -647,7 +647,7 @@ def run_iteration(p, sim_info, iniPar, times, vals, uncs, IRF_tables, hmax,
         for i in range(len(iniPar)):
             p.likelihood[i], p.err_sq[i] = one_sim_likelihood(
                 p, sim_info, IRF_tables, hmax, MCMC_fields, logger, verbose,
-                (i, iniPar[i], times[i], vals[i], uncs[i]))
+                (i, np.array(iniPar[i]), times[i], vals[i], uncs[i]))
 
     if prev_p is not None:
         logger.info("Likelihood of proposed move: {}".format(np.sum(p.likelihood)))

--- a/metropolis.py
+++ b/metropolis.py
@@ -588,7 +588,14 @@ def one_sim_likelihood(p, sim_info, IRF_tables, hmax, MCMC_fields, logger, verbo
             scale_shift = 0
 
         else:
-            scale_shift = p.get_scale_factor(MCMC_fields.get("scale_factor", None), i)
+            fs = MCMC_fields.get("scale_factor", None)
+            if (fs is not None and i in fs[1]):
+                if fs[2] is not None and len(fs[2]) > 0:
+                    scale_shift = np.log10(getattr(p, f"_s{search_c_grps(fs[2], i)}"))
+                else:
+                    scale_shift = np.log10(getattr(p, f"_s{i}"))
+            else:
+                scale_shift = 0
             
         # TODO: accomodate multiple experiments, just like bayes
         # TRPL must be positive!

--- a/sim_utils.py
+++ b/sim_utils.py
@@ -165,25 +165,9 @@ class Parameters():
             is used.
         """
         if scale_info is None:
-            pass
-        elif scale_info[0] == "global":
-            self._s = 1
-        elif scale_info[0] == "ind":
-            setattr(self, f"_s{i}", 1)
+            return
+        setattr(self, f"_s{i}", 1)
         return
-    
-    def get_scale_factor(self, scale_info, i):
-        """ Returns the scale_factor for the ith measurement. 
-            Return is log, since scale_factors always have do_log=1
-        """
-        scale_shift = 0
-        if scale_info is None:
-            pass
-        elif scale_info[0] == "global":
-            scale_shift = np.log10(self._s)
-        elif scale_info[0] == "ind":
-            scale_shift = np.log10(getattr(self, f"_s{i}"))
-        return scale_shift
 
 
 class Covariance():


### PR DESCRIPTION
1. Make scale_f work the same as the fittables, so that we can define constraint groups for scale_fs too
2. Convert fittable_fluences and fittable_alpha to be scale_factor-like modifiers on fluences and alpha values listed in the input file, rather than the fluence values themselves. E.g. a fittable_fluence of 0.5 means the input fluence is being halved before it gets sent to the simulation.
3. Allow an initial guess list as an optional 4th element of the fittable_fluences entry.