### PR TITLE
Allow different model sigma for different meas_types

### DIFF
--- a/Tests/test_MCMC_script_gen.py
+++ b/Tests/test_MCMC_script_gen.py
@@ -118,7 +118,7 @@ class TestUtils(unittest.TestCase):
                             "atol": 1e-10,
                             "hmax": 4,
                             "verify_hmax": 0,
-                            "likel2variance_ratio": 500,
+                            "likel2variance_ratio": {"TRPL": 500},
                             "override_equal_mu": 0,
                             "override_equal_s": 0,
                             "log_pl": 1,
@@ -132,10 +132,12 @@ class TestUtils(unittest.TestCase):
                             }
 
         # Compute properly scaled initial model uncertainty from initial variance
-        self.MCMC_fields["annealing"] = (
-            max(initial_variance.values()) *
-            self.MCMC_fields["likel2variance_ratio"],
-            2000, 1e-2)
+        annealing_step = 2000
+        min_sigma = 0.01
+        self.MCMC_fields["annealing"] = ({m:max(initial_variance.values()) * self.MCMC_fields["likel2variance_ratio"][m]
+                                    for m in self.simPar["meas_types"]},
+                                    annealing_step,
+                                    {m:min_sigma for m in self.simPar["meas_types"]})
         return
 
     def test_create_script(self):

--- a/Tests/test_checkpoint.py
+++ b/Tests/test_checkpoint.py
@@ -104,7 +104,7 @@ class TestUtils(unittest.TestCase):
                        "num_iters": num_iters,
                        "solver": ("solveivp",),
                        "model": "std",
-                       "likel2variance_ratio": 500,
+                       "likel2variance_ratio": {"TRPL": 500},
                        "log_pl": 1,
                        "self_normalize": None,
                        "proposal_function": "box",
@@ -118,10 +118,12 @@ class TestUtils(unittest.TestCase):
                        "load_checkpoint": None,
                        }
 
-        MCMC_fields["annealing"] = (
-            max(initial_variance.values()) *
-            MCMC_fields["likel2variance_ratio"],
-            2000, 1e-2)
+        annealing_step = 2000
+        min_sigma = 0.01
+        MCMC_fields["annealing"] = ({m:max(initial_variance.values()) * MCMC_fields["likel2variance_ratio"][m]
+                                    for m in sim_info["meas_types"]},
+                                    annealing_step,
+                                    {m:min_sigma for m in sim_info["meas_types"]})
 
         self.MS = MetroState(param_info, MCMC_fields, num_iters)
 

--- a/bayes_io.py
+++ b/bayes_io.py
@@ -272,6 +272,20 @@ def remap_constraint_grps(c_grps : list[tuple], select_obs_sets : list) -> list[
         
     return new_c_grps
 
+def add_annealing(MCMC_fields, initial_variance, meas_types, annealing_step=999999, min_sigma=0.01):
+    """Append the annealing tuple to MCMC_fields"""
+
+    if isinstance(MCMC_fields["likel2variance_ratio"], (int, float)):
+        MCMC_fields["annealing"] = ({m:max(initial_variance.values()) * MCMC_fields["likel2variance_ratio"]
+                                     for m in meas_types},
+                                    annealing_step,
+                                    {m:min_sigma for m in meas_types})
+    elif isinstance(MCMC_fields["likel2variance_ratio"], dict):
+        MCMC_fields["annealing"] = ({m:max(initial_variance.values()) * MCMC_fields["likel2variance_ratio"][m]
+                                     for m in meas_types},
+                                    annealing_step,
+                                    {m:min_sigma for m in meas_types})
+
 def read_config_script_file(path):
     with open(path, 'r') as ifstream:
         grid = {}
@@ -564,6 +578,7 @@ def read_config_script_file(path):
 
 def generate_config_script_file(path, simPar, param_info, measurement_flags,
                                 MCMC_fields, verbose=False):
+    add_annealing(MCMC_fields, param_info["init_variance"], simPar["meas_types"])
     validate_grid(simPar)
     validate_param_info(param_info)
     validate_meas_flags(measurement_flags, simPar["num_meas"])
@@ -1000,10 +1015,10 @@ def generate_config_script_file(path, simPar, param_info, measurement_flags,
 
     return
 
-if __name__ == "__main__":
-    grid, param_info, meas_flags, MCMC_fields = read_config_script_file(
-        "mcmc0.txt")
-    print(grid)
-    print(param_info)
-    print(meas_flags)
-    print(MCMC_fields)
+# if __name__ == "__main__":
+#     grid, param_info, meas_flags, MCMC_fields = read_config_script_file(
+#         "mcmc0.txt")
+#     print(grid)
+#     print(param_info)
+#     print(meas_flags)
+#     print(MCMC_fields)

--- a/bayes_io.py
+++ b/bayes_io.py
@@ -38,6 +38,8 @@ def extract_tuples(string, delimiter, dtype=float):
     Converts a string of arbitrary lengthed tuples
     separated by delimiter into a list of tuples
     This one supports inf and -inf as values
+
+    If dtype is supplied, try to typecast out of str
     """
     tuples_as_str = string.split(delimiter)
     tuples = []
@@ -45,15 +47,21 @@ def extract_tuples(string, delimiter, dtype=float):
     for ts in tuples_as_str:
         ts = ts.strip("()")
         vals = ts.split(", ")
-        for i in range(len(vals)):
-            if vals[i] == "-inf":
+        for i, val in enumerate(vals):
+            if val == "-inf":
                 vals[i] = -np.inf
-            elif vals[i] == "inf":
+            elif val == "inf":
                 vals[i] = np.inf
             elif dtype == float:
-                vals[i] = float(vals[i])
+                try:
+                    vals[i] = float(val)
+                except ValueError:
+                    pass
             elif dtype == int:
-                vals[i] = int(vals[i])
+                try:
+                    vals[i] = int(val)
+                except ValueError:
+                    pass
             else:
                 continue
         tuples.append(tuple(vals))
@@ -393,11 +401,25 @@ def read_config_script_file(path):
                     elif line.startswith("Repeat hmax"):
                         MCMC_fields["verify_hmax"] = int(line_split[1])
                     elif line.startswith("Annealing Controls"):
-                        MCMC_fields["annealing"] = tuple(
-                            extract_values(line_split[1].strip("()"), ", "))
+                        splits = line_split[1].split("\t")
+
+                        starts = extract_tuples(splits[0], delimiter="|", dtype=float)
+                        starts = {m[0]:float(m[1]) for m in starts}
+
+                        stops = extract_tuples(splits[2], delimiter="|", dtype=float)
+                        stops = {m[0]:float(m[1]) for m in stops}
+
+
+                        MCMC_fields["annealing"] = (starts, int(splits[1]), stops)
                     elif line.startswith("Likelihood-to-variance"):
-                        MCMC_fields["likel2variance_ratio"] = float(
-                            line_split[1])
+                        try:
+                            l2v = float(line_split[1])
+                            MCMC_fields["likel2variance_ratio"] = {m:l2v for m in grid["meas_types"]}
+                        except ValueError: # Not a float; must be dict
+                            l2v = extract_tuples(line_split[1], delimiter="|", dtype=float)
+                            MCMC_fields["likel2variance_ratio"] = {m[0]:float(m[1]) for m in l2v}
+                            
+                        
                     elif line.startswith("Force equal mu"):
                         MCMC_fields["override_equal_mu"] = int(line_split[1])
                     elif line.startswith("Force equal S"):
@@ -738,18 +760,60 @@ def generate_config_script_file(path, simPar, param_info, measurement_flags,
             verify_hmax = MCMC_fields["verify_hmax"]
             ofstream.write(f"Repeat hmax: {verify_hmax}\n")
 
-        if verbose:
-            ofstream.write("# Annealing schedule parameters.\n"
-                           "# (Starting model uncertainty, steprate, final model uncertainty)\n"
-                           "# Will drop one order of magnitude per STEPRATE samples until FINAL is reached.\n")
-        anneal = MCMC_fields["annealing"]
-        ofstream.write(f"Annealing Controls: {anneal}\n")
+        if "annealing" in MCMC_fields:
+            if verbose:
+                ofstream.write("# Annealing schedule parameters.\n"
+                            "# (Starting model uncertainty, steprate, final model uncertainty)\n"
+                            "# Starting and final model uncertainty will be dicts with one value per measurement type;\n"
+                            "# Steprate should be an integer number of steps.\n"
+                            "# Will drop one order of magnitude per STEPRATE samples until FINAL is reached.\n")
+            anneal = MCMC_fields["annealing"]
+            ofstream.write("Annealing Controls: ")
+            anneal_0 = iter(anneal[0].items())
+            meas_type, start = next(anneal_0)
+            while True:
+                try:
+                    ofstream.write(f"({meas_type}, {start})")
+                    meas_type, start = next(anneal_0)
+                    ofstream.write("|")
+                except StopIteration:
+                    break
+            ofstream.write("\t")
+            ofstream.write(f"{anneal[1]}")
+            ofstream.write("\t")
+
+            anneal_2 = iter(anneal[2].items())
+            meas_type, stop = next(anneal_2)
+            while True:
+                try:
+                    ofstream.write(f"({meas_type}, {stop})")
+                    meas_type, stop = next(anneal_2)
+                    ofstream.write("|")
+                except StopIteration:
+                    break
+            ofstream.write("\n")
 
         if verbose:
             ofstream.write("# Ratio to maintain betwen Model uncertainty and proposal variance.\n"
-                           "# Model uncertainty will be taken as this times proposal variance.\n")
+                           "# Model uncertainty will be taken as this times proposal variance.\n"
+                           "# Should be a single value, or \n"
+                           "# Should be a dict with one value per unique measurement type, \n"
+                           "# which will be shared by all measurements with that type.\n")
         l2v = MCMC_fields["likel2variance_ratio"]
-        ofstream.write(f"Likelihood-to-variance: {l2v}\n")
+        if isinstance(l2v, (int, np.integer, float)):
+            ofstream.write(f"Likelihood-to-variance: {l2v}\n")
+        else:
+            ofstream.write("Likelihood-to-variance: ")
+            l2v = iter(l2v.items())
+            meas_type, val = next(l2v)
+            while True:
+                try:
+                    ofstream.write(f"({meas_type}, {val})")
+                    meas_type, val = next(l2v)
+                    ofstream.write("|")
+                except StopIteration:
+                    break
+            ofstream.write("\n")
 
         if "override_equal_mu" in MCMC_fields:
             if verbose:

--- a/metropolis.py
+++ b/metropolis.py
@@ -537,6 +537,7 @@ def almost_equal(x, x0, threshold=1e-10):
 
 def one_sim_likelihood(p, sim_info, IRF_tables, hmax, MCMC_fields, logger, verbose, args):
     i, iniPar, times, vals, uncs = args
+    meas_type = sim_info["meas_types"][i]
     irf_convolution = MCMC_fields.get("irf_convolution", None)
 
     ff = MCMC_fields.get("fittable_fluences", None)
@@ -616,7 +617,7 @@ def one_sim_likelihood(p, sim_info, IRF_tables, hmax, MCMC_fields, logger, verbo
         sol[where_failed] *= -1
         err_sq = (np.log10(sol) + scale_shift - vals_c) ** 2
         likelihood = - \
-            np.sum(err_sq / (MCMC_fields["current_sigma"]**2 + 2*uncs_c**2))
+            np.sum(err_sq / (MCMC_fields["current_sigma"][meas_type]**2 + 2*uncs_c**2))
 
         if np.isnan(likelihood):
             raise ValueError(f"{i}: Simulation failed: invalid likelihood")

--- a/sim_utils.py
+++ b/sim_utils.py
@@ -19,7 +19,7 @@ class MetroState():
         the states it's been to, and the trial move function used to get the
         next state.
     """
-
+    sim_info: dict
     def __init__(self, param_info, MCMC_fields, num_iters):
         self.p = Parameters(param_info)
 
@@ -46,23 +46,26 @@ class MetroState():
         l2v = self.MCMC_fields["likel2variance_ratio"]
         if k > 0 and l2v > 0 and k % steprate == 0:
 
-            self.MCMC_fields["current_sigma"] *= 0.1
+            for m in self.MCMC_fields["current_sigma"]:
+                self.MCMC_fields["current_sigma"][m] *= 0.1
 
-            self.MCMC_fields["current_sigma"] = max(self.MCMC_fields["current_sigma"],
-                                                    min_sigma)
+                self.MCMC_fields["current_sigma"][m] = max(self.MCMC_fields["current_sigma"][m],
+                                                        min_sigma[m])
 
-            new_variance = self.MCMC_fields["current_sigma"] / l2v
+            # Doesn't matter which meas_type, because all current_sigma are proportional to init_variance
+            random_m = next(iter(self.MCMC_fields["current_sigma"].keys()))
+            new_variance = self.MCMC_fields["current_sigma"][random_m] / l2v[random_m]
             self.variances.apply_values(
                 {param: new_variance for param in self.param_info["names"]})
 
             # Recalculate the previous state's likelihood, for consistency
-
+            meas_types = self.sim_info["meas_types"]
             for i in range(len(self.prev_p.likelihood)):
                 if uncs is not None:
                     exp_unc = 2 * uncs[i] ** 2
                 else:
                     exp_unc = 0
-                new_uncertainty = self.MCMC_fields["current_sigma"]**2 + exp_unc
+                new_uncertainty = self.MCMC_fields["current_sigma"][meas_types[i]]**2 + exp_unc
                 self.prev_p.likelihood[i] = - \
                     np.sum(self.prev_p.err_sq[i] / new_uncertainty)
         return
@@ -106,6 +109,8 @@ class Parameters():
     tauP: float    # Hole bulk nonradiative decayl lifetime
     eps: float     # Relative dielectric cofficient
     Tm: float      # Temperature
+    likelihood: list # Current likelihood of each simulation vs its respective measurement
+    err_sq: list     # Current squared error of each simulation vs its respective measurement
 
     def __init__(self, param_info):
         self.param_names = param_info["names"]

--- a/sim_utils.py
+++ b/sim_utils.py
@@ -34,7 +34,7 @@ class MetroState():
 
         self.param_info = param_info
         self.MCMC_fields = MCMC_fields
-        self.MCMC_fields["current_sigma"] = self.MCMC_fields["annealing"][0]
+        self.MCMC_fields["current_sigma"] = dict(self.MCMC_fields["annealing"][0])
         return
 
     def anneal(self, k, uncs=None):

--- a/sim_utils.py
+++ b/sim_utils.py
@@ -44,7 +44,7 @@ class MetroState():
         steprate = self.MCMC_fields["annealing"][1]
         min_sigma = self.MCMC_fields["annealing"][2]
         l2v = self.MCMC_fields["likel2variance_ratio"]
-        if k > 0 and l2v > 0 and k % steprate == 0:
+        if k > 0 and k % steprate == 0:
 
             for m in self.MCMC_fields["current_sigma"]:
                 self.MCMC_fields["current_sigma"][m] *= 0.1


### PR DESCRIPTION
We want to infer on combinations of TRPL and TRTS measurement data, but since TRPL has higher time res / longer delay times, inferences could over-weight TRPL if they are treated with the same model uncertainty. We don't know exactly how to choose different model uncertainties right now, but this update makes it possible for them to have different model uncertainties in general.

1. Make MCMC_fields["likelihood2variance"] and MCMC_fields["annealing"] accept different values of the model uncertainty for each measurement type. A dict[meas_type: l2v value] should suffice.
2. Modify the anneal function in metropolis.py to choose the appropriate unc for the meas_type of the current simulation.

This also makes the annealing calculation cumbersome in MCMC_script_writer.py, so MCMC_fields["annealing"] should also be made optional, and its calculation should be moved to bayes_io.py.