### PR TITLE
Quicksim entry click menu

### DIFF
--- a/GUI/quicksim_entry_popup.py
+++ b/GUI/quicksim_entry_popup.py
@@ -28,7 +28,7 @@ class QSEClickmenu(Clickmenu):
         self.menu.add_command(label="Copy Row", command=self.copy_row)
 
     def copy_row(self):
-        print("help")
+        print("latest click was at ", self.latest_event)
 
 
 class QuicksimEntryPopup(Popup):
@@ -43,8 +43,6 @@ class QuicksimEntryPopup(Popup):
         self.toplevel.attributes('-topmost', 'false')
         self.toplevel.protocol("WM_DELETE_WINDOW", partial(self.on_close, False))
         self.load_keybinds()
-
-        
 
         self.c_frame = self.window.Panel(self.toplevel, width=WIDTH,
                                               height=100, color=DARK_GREY)

--- a/GUI/quicksim_entry_popup.py
+++ b/GUI/quicksim_entry_popup.py
@@ -17,6 +17,7 @@ from gui_styles import LABEL_KWARGS
 
 WIDTH = 970
 HEIGHT = 600
+EV_FRAME_OFFSET = (60, 30)
 DEFAULT_N_SIMS = 3
 KEYBIND_DIR = "keybinds"
 AVAILABLE_MEAS = ["TRPL", "TRTS"]
@@ -26,9 +27,38 @@ class QSEClickmenu(Clickmenu):
     def __init__(self, window, master, chart):
         super().__init__(window, master, chart)
         self.menu.add_command(label="Copy Row", command=self.copy_row)
+        self.menu.add_command(label="Paste Row", command=self.paste_row)
+        self.clipboard = []
+
+    def show(self, event):
+        """Check that click falls within a row before showing"""
+        row = int((event.y - EV_FRAME_OFFSET[0]) / EV_FRAME_OFFSET[1])
+        if row < 0:
+            # Clicked too high
+            return
+
+        if row >= self.window.n_sims:
+            # Clicked too low
+            return
+
+        super().show(event)
 
     def copy_row(self):
-        print("latest click was at ", self.latest_event)
+        """Copy selected row's values"""
+        row = int((self.latest_event[1] - EV_FRAME_OFFSET[0]) / EV_FRAME_OFFSET[1])
+
+        self.clipboard = []
+        for ev in self.window.ext_var:
+            self.clipboard.append(self.window.ext_var[ev][row].get())
+
+    def paste_row(self):
+        """Paste previously copied row into selected row"""
+        if len(self.clipboard) == 0:
+            return
+
+        row = int((self.latest_event[1] - EV_FRAME_OFFSET[0]) / EV_FRAME_OFFSET[1])
+        for i, ev in enumerate(self.window.ext_var):
+            self.window.ext_var[ev][row].set(self.clipboard[i])
 
 
 class QuicksimEntryPopup(Popup):
@@ -175,13 +205,13 @@ class QuicksimEntryPopup(Popup):
         """
         self.ev_frame.widgets[f"Number-{i}"] = tk.Label(self.ev_frame.widget, text=f"{i+1}.", width=4, border=3,
                                                             background=LIGHT_GREY)
-        self.ev_frame.widgets[f"Number-{i}"].place(x=0, y=60+30*i)
+        self.ev_frame.widgets[f"Number-{i}"].place(x=0, y=EV_FRAME_OFFSET[0]+EV_FRAME_OFFSET[1]*i)
         for e, ev in enumerate(self.ext_var):
             tk.Label(self.ev_frame.widget, text=ev, **LABEL_KWARGS).place(x=60+110*e, y=20)
             self.ext_var[ev].append(tk.StringVar())
             self.ev_frame.widgets[f"{e}-{i}"] = tk.Entry(master=self.ev_frame.widget, width=16, border=3,
                 textvariable=self.ext_var[ev][-1], highlightthickness=2, highlightcolor=LIGHT_GREY)
-            self.ev_frame.widgets[f"{e}-{i}"].place(x=60+110*e, y=60+30*i)
+            self.ev_frame.widgets[f"{e}-{i}"].place(x=60+110*e, y=EV_FRAME_OFFSET[0]+EV_FRAME_OFFSET[1]*i)
 
     def contract_ev_frame(self, i : int) -> None:
         """Remove widgets belonging to the deleted ith simulation"""

--- a/GUI/quicksim_entry_popup.py
+++ b/GUI/quicksim_entry_popup.py
@@ -10,6 +10,7 @@ from tkinter import filedialog
 from functools import partial
 from forward_solver import MODELS
 
+from rclickmenu import Clickmenu, CLICK_EVENTS
 from popup import Popup
 from gui_colors import LIGHT_GREY, BLACK, WHITE, DARK_GREY, RED
 from gui_styles import LABEL_KWARGS
@@ -19,6 +20,16 @@ HEIGHT = 600
 DEFAULT_N_SIMS = 3
 KEYBIND_DIR = "keybinds"
 AVAILABLE_MEAS = ["TRPL", "TRTS"]
+
+class QSEClickmenu(Clickmenu):
+
+    def __init__(self, window, master, chart):
+        super().__init__(window, master, chart)
+        self.menu.add_command(label="Copy Row", command=self.copy_row)
+
+    def copy_row(self):
+        print("help")
+
 
 class QuicksimEntryPopup(Popup):
 
@@ -33,10 +44,15 @@ class QuicksimEntryPopup(Popup):
         self.toplevel.protocol("WM_DELETE_WINDOW", partial(self.on_close, False))
         self.load_keybinds()
 
+        
+
         self.c_frame = self.window.Panel(self.toplevel, width=WIDTH,
                                               height=100, color=DARK_GREY)
         self.ev_frame = self.window.Panel(self.toplevel, width=WIDTH, height=480,
                                          color=LIGHT_GREY)
+        
+        self.clickmenu = QSEClickmenu(self, self.toplevel, self.ev_frame.widget)
+        self.toplevel.bind(CLICK_EVENTS["click"]["right"], self.clickmenu.show)
 
         self.n_sims = DEFAULT_N_SIMS
         self.c_frame.variables["n_sims"] = tk.StringVar(value=str(self.n_sims))

--- a/GUI/rclickmenu.py
+++ b/GUI/rclickmenu.py
@@ -20,6 +20,6 @@ class Clickmenu():
 
         try:
             self.menu.tk_popup(event.x_root, event.y_root)
-            self.latest_event = (event.x_root, event.y_root)
+            self.latest_event = (event.x, event.y)
         finally:
             self.menu.grab_release()

--- a/GUI/rclickmenu.py
+++ b/GUI/rclickmenu.py
@@ -11,6 +11,7 @@ class Clickmenu():
         self.master = master
         self.target_widget = target_widget
         self.menu = Menu(self.master, tearoff=0)
+        self.latest_event = (-1, -1)
 
     def show(self, event):
         """Display menu at click event location"""
@@ -19,5 +20,6 @@ class Clickmenu():
 
         try:
             self.menu.tk_popup(event.x_root, event.y_root)
+            self.latest_event = (event.x_root, event.y_root)
         finally:
             self.menu.grab_release()

--- a/GUI/rclickmenu.py
+++ b/GUI/rclickmenu.py
@@ -1,11 +1,8 @@
 """Menu of options that should appear on right-click"""
-import platform
-from io import BytesIO
 from tkinter import Menu
-from PIL import Image
-OSTYPE = platform.system().lower()
-if OSTYPE == "windows":
-    import win32clipboard
+
+CLICK_EVENTS = {#"key": {"escape": "<Escape>", "enter": "<Return>"},
+                "click": {"left": "<Button-1>", "right": "<Button-3>"},}
 
 class Clickmenu():
     """Menu of options that should appear on right-click"""
@@ -14,8 +11,6 @@ class Clickmenu():
         self.master = master
         self.chart = chart
         self.menu = Menu(self.master, tearoff=0)
-        self.menu.add_command(label="Copy", command=self.copy_fig)
-
 
     def show(self, event):
         """Display menu at click event location"""
@@ -26,25 +21,3 @@ class Clickmenu():
             self.menu.tk_popup(event.x_root, event.y_root)
         finally:
             self.menu.grab_release()
-
-    def copy_fig(self):
-        """
-        Adapted from: addcopyfighandler by joshburnett (09/14/2023)
-        https://github.com/joshburnett/addcopyfighandler
-        """
-        if OSTYPE != "windows":
-            raise NotImplementedError("Copy-paste only supported on Windows (WIP)")
-
-        with BytesIO() as buf:
-            self.chart.canvas.figure.savefig(buf, dpi=600, format="png")
-
-            image = Image.open(buf)
-            with BytesIO() as output:
-                image.convert("RGB").save(output, "BMP")
-                data = output.getvalue()[14:]  # The file header off-set of BMP is 14 bytes
-                format_id = win32clipboard.CF_DIB  # DIB = device independent bitmap
-
-        win32clipboard.OpenClipboard()
-        win32clipboard.EmptyClipboard()
-        win32clipboard.SetClipboardData(format_id, data)
-        win32clipboard.CloseClipboard()

--- a/GUI/rclickmenu.py
+++ b/GUI/rclickmenu.py
@@ -6,15 +6,15 @@ CLICK_EVENTS = {#"key": {"escape": "<Escape>", "enter": "<Return>"},
 
 class Clickmenu():
     """Menu of options that should appear on right-click"""
-    def __init__(self, window, master, chart) -> None:
+    def __init__(self, window, master, target_widget) -> None:
         self.window = window
         self.master = master
-        self.chart = chart
+        self.target_widget = target_widget
         self.menu = Menu(self.master, tearoff=0)
 
     def show(self, event):
         """Display menu at click event location"""
-        if event.widget != self.chart.widget:
+        if event.widget != self.target_widget:
             return
 
         try:

--- a/GUI/tkgui.py
+++ b/GUI/tkgui.py
@@ -21,7 +21,8 @@ if OSTYPE == "windows":
 class MainClickmenu(Clickmenu):
 
     def __init__(self, window, master, chart):
-        super().__init__(window, master, chart)
+        super().__init__(window, master, target_widget=chart.widget)
+        self.chart = chart
         self.menu.add_command(label="Copy", command=self.copy_fig)
 
     def copy_fig(self):

--- a/GUI/tkgui.py
+++ b/GUI/tkgui.py
@@ -2,17 +2,49 @@
 First of a two-stage tkinter GUI construction - this one plots all of the widgets
 where window.py then adds functionality
 """
+import platform
+from io import BytesIO
 import tkinter as tk
+from PIL import Image
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 from matplotlib.backends._backend_tk import NavigationToolbar2Tk
 from matplotlib.figure import Figure
 
-from rclickmenu import Clickmenu
+from rclickmenu import Clickmenu, CLICK_EVENTS
 from gui_colors import BLACK, WHITE, LIGHT_GREY, GREY, DARK_GREY
 from gui_styles import MENU_KWARGS, LABEL_KWARGS
 
-events = {"key": {"escape": "<Escape>", "enter": "<Return>"},
-          "click": {"left": "<Button-1>", "right": "<Button-3>"}}
+OSTYPE = platform.system().lower()
+if OSTYPE == "windows":
+    import win32clipboard
+
+class MainClickmenu(Clickmenu):
+
+    def __init__(self, window, master, chart):
+        super().__init__(window, master, chart)
+        self.menu.add_command(label="Copy", command=self.copy_fig)
+
+    def copy_fig(self):
+        """
+        Adapted from: addcopyfighandler by joshburnett (09/14/2023)
+        https://github.com/joshburnett/addcopyfighandler
+        """
+        if OSTYPE != "windows":
+            raise NotImplementedError("Copy-paste only supported on Windows (WIP)")
+
+        with BytesIO() as buf:
+            self.chart.canvas.figure.savefig(buf, dpi=600, format="png")
+
+            image = Image.open(buf)
+            with BytesIO() as output:
+                image.convert("RGB").save(output, "BMP")
+                data = output.getvalue()[14:]  # The file header off-set of BMP is 14 bytes
+                format_id = win32clipboard.CF_DIB  # DIB = device independent bitmap
+
+        win32clipboard.OpenClipboard()
+        win32clipboard.EmptyClipboard()
+        win32clipboard.SetClipboardData(format_id, data)
+        win32clipboard.CloseClipboard()
 
 class TkGUI():
     """GUI with all widgets plotted"""
@@ -69,8 +101,8 @@ class TkGUI():
         self.widget.option_add("*tearOff", False)
         self.chart = self.Chart(self.widget, 600, 600)
 
-        self.clickmenu = Clickmenu(self, self.widget, self.chart)
-        self.widget.bind(events["click"]["right"], self.clickmenu.show)
+        self.clickmenu = MainClickmenu(self, self.widget, self.chart)
+        self.widget.bind(CLICK_EVENTS["click"]["right"], self.clickmenu.show)
 
         self.chart.place(0, 0)
         self.side_panel = self.Panel(self.widget, 400, 430, GREY)


### PR DESCRIPTION
Right now it's awkward to move or change the order of rows of parameters on the quicksim entry popup. Using the existing ClickMenu code, this PR adds right-click buttons to copy and paste rows of parameters on the quicksim entry popup.