### PR TITLE
Improved checkpoints

### DIFF
--- a/MCMC_script_writer.py
+++ b/MCMC_script_writer.py
@@ -155,10 +155,7 @@ if __name__ == "__main__":
                    "one_param_at_a_time": 0,
                    "hard_bounds": 1,
                    "force_min_y": 0,
-                   "checkpoint_dirname": os.path.join(output_path, "Checkpoints"),
-                   "checkpoint_header": f"CPU{jobid}",
                    "checkpoint_freq": 12000,
-                   # f"checkpointCPU{jobid}_30000.pik",
                    "load_checkpoint": None,
                    }
 

--- a/Tests/test_checkpoint.py
+++ b/Tests/test_checkpoint.py
@@ -112,7 +112,7 @@ class TestUtils(unittest.TestCase):
                        "hard_bounds": 1,
                        "checkpoint_dirname": os.path.join(".",
                                                           "test-Checkpoints"),
-                       "checkpoint_header": "",
+                       "checkpoint_header": "checkpoint",
                        "checkpoint_freq": 5,
                        # f"checkpointCPU{jobid}_30000.pik",
                        "load_checkpoint": None,
@@ -145,7 +145,7 @@ class TestUtils(unittest.TestCase):
 
     def test_checkpoint(self):
         with open(os.path.join(os.path.join(".", "test-Checkpoints"),
-                               "checkpoint_5.pik"), 'rb') as ifstream:
+                               "checkpoint.pik"), 'rb') as ifstream:
             self.MS_from_chpt = pickle.load(ifstream)
             np.random.set_state(self.MS_from_chpt.random_state)
             starting_iter = 5 + 1

--- a/bayes_io.py
+++ b/bayes_io.py
@@ -999,7 +999,7 @@ def generate_config_script_file(path, simPar, param_info, measurement_flags,
 
         if verbose:
             ofstream.write("# Directory checkpoint files stored in.\n")
-        chpt_d = MCMC_fields["checkpoint_dirname"]
+        chpt_d = MCMC_fields.get("checkpoint_dirname", MCMC_fields["output_path"])
         ofstream.write(f"Checkpoint dir: {chpt_d}\n")
 
         if verbose:

--- a/bayes_io.py
+++ b/bayes_io.py
@@ -402,6 +402,8 @@ def read_config_script_file(path):
                 if (init_flag == 's'):
                     if line.startswith("Num iters"):
                         MCMC_fields["num_iters"] = int(line_split[1])
+                    elif line.startswith("Starting iter"):
+                        MCMC_fields["starting_iter"] = int(line_split[1])
                     elif line.startswith("Solver name"):
                         MCMC_fields["solver"] = tuple(line_split[1].split('\t'))
                     elif line.startswith("Model name"):
@@ -735,6 +737,12 @@ def generate_config_script_file(path, simPar, param_info, measurement_flags,
             ofstream.write("# How many samples to propose.\n")
         num_iters = MCMC_fields["num_iters"]
         ofstream.write(f"Num iters: {num_iters}\n")
+        if verbose:
+            ofstream.write("# Starting sample number. This is always zero for new inferences.\n"
+                           "# If loading a checkpoint, will continue from this iteration if provided,\n"
+                           "# or where the checkpoint left off by default.\n")
+        starting_iter = MCMC_fields.get("starting_iter", 0)
+        ofstream.write(f"Starting iter: {starting_iter}\n")
         if verbose:
             ofstream.write(
                 "# Which solver engine to use - solveivp (more robust), odeint (sometimes faster),"

--- a/bayes_io.py
+++ b/bayes_io.py
@@ -1002,11 +1002,11 @@ def generate_config_script_file(path, simPar, param_info, measurement_flags,
         chpt_d = MCMC_fields.get("checkpoint_dirname", MCMC_fields["output_path"])
         ofstream.write(f"Checkpoint dir: {chpt_d}\n")
 
-        if verbose:
-            ofstream.write(
-                "# An optional tag to append to the filename of each checkpoint.\n")
-        chpt_h = MCMC_fields["checkpoint_header"]
-        ofstream.write(f"Checkpoint fileheader: {chpt_h}\n")
+        if "checkpoint_header" in MCMC_fields:
+            if verbose:
+                ofstream.write("# A name for each checkpoint file.\n")
+            chpt_h = MCMC_fields["checkpoint_header"]
+            ofstream.write(f"Checkpoint fileheader: {chpt_h}\n")
 
         if verbose:
             ofstream.write("# Checkpoint saved every 'this many' samples.\n")

--- a/bayes_validate.py
+++ b/bayes_validate.py
@@ -300,7 +300,6 @@ def validate_MCMC_fields(MCMC_fields: dict, num_measurements: int,
                      "likel2variance_ratio",
                      "log_pl", "self_normalize",
                      "proposal_function", "one_param_at_a_time",
-                     "checkpoint_header",
                      "checkpoint_freq",
                      "load_checkpoint",
                      )
@@ -517,11 +516,12 @@ def validate_MCMC_fields(MCMC_fields: dict, num_measurements: int,
         else:
             raise ValueError("Invalid char in checkpoint dirname")
 
-    chpt_h = MCMC_fields["checkpoint_header"]
-    if check_valid_filename(chpt_h):
-        pass
-    else:
-        raise ValueError("Invalid char in checkpoint header")
+    if "checkpoint_header" in MCMC_fields:
+        chpt_h = MCMC_fields["checkpoint_header"]
+        if check_valid_filename(chpt_h):
+            pass
+        else:
+            raise ValueError("Invalid char in checkpoint header")
 
     chpt_f = MCMC_fields["checkpoint_freq"]
     if isinstance(chpt_f, (int, np.integer)) and chpt_f > 0:

--- a/bayes_validate.py
+++ b/bayes_validate.py
@@ -300,7 +300,7 @@ def validate_MCMC_fields(MCMC_fields: dict, num_measurements: int,
                      "likel2variance_ratio",
                      "log_pl", "self_normalize",
                      "proposal_function", "one_param_at_a_time",
-                     "checkpoint_dirname", "checkpoint_header",
+                     "checkpoint_header",
                      "checkpoint_freq",
                      "load_checkpoint",
                      )
@@ -510,11 +510,12 @@ def validate_MCMC_fields(MCMC_fields: dict, num_measurements: int,
     else:
         raise ValueError("one_param_at_a_time invalid - must be 0 or 1")
 
-    chpt_d = MCMC_fields["checkpoint_dirname"]
-    if check_valid_filename(chpt_d):
-        pass
-    else:
-        raise ValueError("Invalid char in checkpoint dirname")
+    if "checkpoint_dirname" in MCMC_fields:
+        chpt_d = MCMC_fields["checkpoint_dirname"]
+        if check_valid_filename(chpt_d):
+            pass
+        else:
+            raise ValueError("Invalid char in checkpoint dirname")
 
     chpt_h = MCMC_fields["checkpoint_header"]
     if check_valid_filename(chpt_h):

--- a/bayes_validate.py
+++ b/bayes_validate.py
@@ -333,6 +333,13 @@ def validate_MCMC_fields(MCMC_fields: dict, num_measurements: int,
     else:
         raise ValueError("Invalid number of iterations")
     
+    if "starting_iter" in MCMC_fields:
+        starting_iter = MCMC_fields["starting_iter"]
+        if isinstance(starting_iter, (int, np.integer)) and starting_iter >= 0:
+            pass
+        else:
+            raise ValueError("Invalid starting iteration")
+    
     if isinstance(MCMC_fields["model"], str) and MCMC_fields["model"] in MODELS:
         pass
     else:

--- a/main.py
+++ b/main.py
@@ -91,11 +91,12 @@ if __name__ == "__main__":
     logger.info("Acceptance rate: {}".format(
         np.sum(MS.H.accept) / len(MS.H.accept.flatten())))
 
-    # Successful completion - checkpoints not needed anymore
-    chpt_header = MS.MCMC_fields["checkpoint_header"]
-    for chpt in os.listdir(MS.MCMC_fields["checkpoint_dirname"]):
-        if f"checkpoint{chpt_header}" in chpt:
-            os.remove(os.path.join(MS.MCMC_fields["checkpoint_dirname"], chpt))
+    # Successful completion - remove all non-final checkpoints
+    if "checkpoint_header" in MS.MCMC_fields:
+        chpt_header = MS.MCMC_fields["checkpoint_header"]
+        for chpt in os.listdir(MS.MCMC_fields["checkpoint_dirname"]):
+            if chpt.startswith(chpt_header) and not chpt.endswith("final.pik") and not chpt.endswith(".log"):
+                os.remove(os.path.join(MS.MCMC_fields["checkpoint_dirname"], chpt))
     # os.rmdir(MS.MCMC_fields["checkpoint_dirname"])
 
     stop_logging(logger, handler, 0)

--- a/metropolis.py
+++ b/metropolis.py
@@ -776,7 +776,7 @@ def main_metro_loop(MS, starting_iter, num_iters,
         if checkpoint_freq is not None and k % checkpoint_freq == 0:
             chpt_header = MS.MCMC_fields["checkpoint_header"]
             chpt_fname = os.path.join(MS.MCMC_fields["checkpoint_dirname"],
-                                      f"checkpoint{chpt_header}.pik")
+                                    f"{chpt_header}.pik")
             logger.info(f"Saving checkpoint at k={k}; fname {chpt_fname}")
             MS.random_state = np.random.get_state()
             MS.checkpoint(chpt_fname)
@@ -797,7 +797,7 @@ def all_signal_handler(func):
 
 
 def metro(sim_info, iniPar, e_data, MCMC_fields, param_info,
-          verbose=False, export_path=None, logger=None):
+          verbose=False, export_path="", logger=None):
 
     if logger is None:  # Require a logger
         logger, handler = start_logging(log_dir=MCMC_fields["output_path"],
@@ -818,6 +818,8 @@ def metro(sim_info, iniPar, e_data, MCMC_fields, param_info,
     if load_checkpoint is None:
         MS = MetroState(param_info, MCMC_fields, num_iters)
         MS.checkpoint(os.path.join(MS.MCMC_fields["output_path"], export_path))
+        if "checkpoint_header" not in MS.MCMC_fields:
+            MS.MCMC_fields["checkpoint_header"] = export_path[:export_path.find(".pik")]
 
         starting_iter = 1
 

--- a/sim_utils.py
+++ b/sim_utils.py
@@ -35,6 +35,8 @@ class MetroState():
         self.param_info = param_info
         self.MCMC_fields = MCMC_fields
         self.MCMC_fields["current_sigma"] = dict(self.MCMC_fields["annealing"][0])
+        self.latest_iter = 0
+        self.random_state = np.random.get_state()
         return
 
     def anneal(self, k, uncs=None, force=False, step=DEFAULT_ANN_STEP):


### PR DESCRIPTION
The existing checkpoints system is feeling clunky. This is especially so in a multi-CPU setting in which different CPUs may progress at different rates, leading to a large number of checkpoint files stamped with different iteration counts.

Instead, we are pushing toward having there only ever be one checkpoint file per CPU, which also doubles as the final .pik file. This single file is simply overwritten whenever a new checkpoint is saved or the program completes. For backwards compatibility we will also preserve the ability to save separate checkpoint files.

Required changes:
1. Remove the latest iter count from checkpoint names and instead store this in the file itself.
2. Make the "checkpoint_dirname" and "checkpoint_header" settings optional, and have them point to the final .pik file location by default.
3. Add a new field "starting_iter", which triggers a reset to starting_iter if loading a checkpoint that has progressed beyond the starting_iter'th iteration. If not provided, loading a checkpoint starts the program at the saved latest iter count and no truncation is needed.