### PR TITLE
Visibility popup

### DIFF
--- a/GUI/activate_chain_popup.py
+++ b/GUI/activate_chain_popup.py
@@ -16,10 +16,10 @@ class ActivateChainPopup(Popup):
 
     def __init__(self, window, master) -> None:
         """Toggle the visibility of specific MCMC chains."""
-        n_cols = 1 + len(window.file_names) // CHAINS_PER_ROW
+        n_cols = 1 + len(window.chains) // CHAINS_PER_ROW
         super().__init__(window, master,
                          n_cols * WIDTH_PER_COL,
-                         BASE_HEIGHT + HEIGHT_PER_CHAIN * min(CHAINS_PER_ROW, len(window.file_names)))
+                         BASE_HEIGHT + HEIGHT_PER_CHAIN * min(CHAINS_PER_ROW, len(window.chains)))
         self._toggle_all = tk.IntVar(value=1)
         self._toggle_all.trace("w", self.on_toggle_all)
         self.toplevel.attributes('-topmost', 'true')
@@ -27,9 +27,9 @@ class ActivateChainPopup(Popup):
         tk.Label(self.toplevel, text="Display:", background=LIGHT_GREY).grid(row=0, column=0, columnspan=99)
         tk.Checkbutton(self.toplevel, text="Toggle All", variable=self._toggle_all, onvalue=1, offvalue=0,
                        background=LIGHT_GREY).grid(row=1,column=0,columnspan=99)
-        for i, file_name in enumerate(self.window.file_names):
-            tk.Checkbutton(self.toplevel, text=os.path.basename(file_name),
-                           variable=self.window.file_names[file_name],
+        for i, chain in enumerate(self.window.chains):
+            tk.Checkbutton(self.toplevel, text=os.path.basename(chain.fname),
+                           variable=chain.visible,
                            onvalue=1, offvalue=0, background=LIGHT_GREY).grid(row=i%CHAINS_PER_ROW+2, column=2*(i//CHAINS_PER_ROW))
             
             tk.Label(self.toplevel, width=4, height=2, background=PLOT_COLOR_CYCLE[i % len(PLOT_COLOR_CYCLE)]).grid(row=i%CHAINS_PER_ROW+2,column=1+2*(i//CHAINS_PER_ROW), padx=(0,5))
@@ -37,10 +37,10 @@ class ActivateChainPopup(Popup):
     def on_toggle_all(self, *args) -> None:
         """Sets visibility of all loaded chains."""
         v = self._toggle_all.get()
-        for file_name in self.window.file_names:
-            self.window.file_names[file_name].trace_vdelete("w", self.window.file_names[file_name].trace_id)
-            self.window.file_names[file_name].set(v)
-            self.window.file_names[file_name].trace_id = self.window.file_names[file_name].trace("w", self.window.on_active_chain_update)
+        for chain in self.window.chains:
+            chain.visible.trace_vdelete("w", chain.visible.trace_id)
+            chain.visible.set(v)
+            chain.visible.trace_id = chain.visible.trace("w", self.window.on_active_chain_update)
 
         self.window.on_active_chain_update()
 

--- a/GUI/activate_chain_popup.py
+++ b/GUI/activate_chain_popup.py
@@ -10,7 +10,7 @@ from gui_colors import LIGHT_GREY, PLOT_COLOR_CYCLE
 
 WIDTH_PER_COL = 180
 CHAINS_PER_ROW = 8
-BASE_HEIGHT = 10
+BASE_HEIGHT = 20
 HEIGHT_PER_CHAIN = 40
 class ActivateChainPopup(Popup):
 
@@ -20,15 +20,29 @@ class ActivateChainPopup(Popup):
         super().__init__(window, master,
                          n_cols * WIDTH_PER_COL,
                          BASE_HEIGHT + HEIGHT_PER_CHAIN * min(CHAINS_PER_ROW, len(window.file_names)))
+        self._toggle_all = tk.IntVar(value=1)
+        self._toggle_all.trace("w", self.on_toggle_all)
         self.toplevel.attributes('-topmost', 'true')
         self.toplevel.title("Toggle MMC chains")
         tk.Label(self.toplevel, text="Display:", background=LIGHT_GREY).grid(row=0, column=0, columnspan=99)
+        tk.Checkbutton(self.toplevel, text="Toggle All", variable=self._toggle_all, onvalue=1, offvalue=0,
+                       background=LIGHT_GREY).grid(row=1,column=0,columnspan=99)
         for i, file_name in enumerate(self.window.file_names):
             tk.Checkbutton(self.toplevel, text=os.path.basename(file_name),
                            variable=self.window.file_names[file_name],
-                           onvalue=1, offvalue=0, background=LIGHT_GREY).grid(row=i%CHAINS_PER_ROW+1, column=2*(i//CHAINS_PER_ROW))
+                           onvalue=1, offvalue=0, background=LIGHT_GREY).grid(row=i%CHAINS_PER_ROW+2, column=2*(i//CHAINS_PER_ROW))
             
-            tk.Label(self.toplevel, width=4, height=2, background=PLOT_COLOR_CYCLE[i % len(PLOT_COLOR_CYCLE)]).grid(row=i%CHAINS_PER_ROW+1,column=1+2*(i//CHAINS_PER_ROW), padx=(0,5))
+            tk.Label(self.toplevel, width=4, height=2, background=PLOT_COLOR_CYCLE[i % len(PLOT_COLOR_CYCLE)]).grid(row=i%CHAINS_PER_ROW+2,column=1+2*(i//CHAINS_PER_ROW), padx=(0,5))
+
+    def on_toggle_all(self, *args) -> None:
+        """Sets visibility of all loaded chains."""
+        v = self._toggle_all.get()
+        for file_name in self.window.file_names:
+            self.window.file_names[file_name].trace_vdelete("w", self.window.file_names[file_name].trace_id)
+            self.window.file_names[file_name].set(v)
+            self.window.file_names[file_name].trace_id = self.window.file_names[file_name].trace("w", self.window.on_active_chain_update)
+
+        self.window.on_active_chain_update()
 
     def on_close(self) -> None:
         self.is_open = False

--- a/GUI/activate_chain_popup.py
+++ b/GUI/activate_chain_popup.py
@@ -19,7 +19,7 @@ class ActivateChainPopup(Popup):
         n_cols = 1 + len(window.file_names) // CHAINS_PER_ROW
         super().__init__(window, master,
                          n_cols * WIDTH_PER_COL,
-                         BASE_HEIGHT + HEIGHT_PER_CHAIN * len(window.file_names))
+                         BASE_HEIGHT + HEIGHT_PER_CHAIN * min(CHAINS_PER_ROW, len(window.file_names)))
         self.toplevel.attributes('-topmost', 'true')
         self.toplevel.title("Toggle MMC chains")
         tk.Label(self.toplevel, text="Display:", background=LIGHT_GREY).grid(row=0, column=0, columnspan=99)

--- a/GUI/quicksim.py
+++ b/GUI/quicksim.py
@@ -55,12 +55,12 @@ class QuicksimManager():
             IRF_tables = dict()
 
         simulate = []
-        for fname in self.window.file_names:
-            if self.window.file_names[fname].get() == 0: # Don't simulate disabled chains
+        for chain in self.window.chains:
+            if chain.visible.get() == 0: # Don't simulate disabled chains
                 continue
             param_info = {}
-            param_info["names"] = [x for x in self.window.data[fname] if x not in self.window.sp.func]
-            param_info["init_guess"] = {x: self.window.data[fname][x][-1] for x in param_info["names"]}
+            param_info["names"] = [x for x in self.window.data[chain.fname] if x not in self.window.sp.func]
+            param_info["init_guess"] = {x: self.window.data[chain.fname][x][-1] for x in param_info["names"]}
             param_info["active"] = {x: True for x in param_info["names"]}
             param_info["unit_conversions"] = {"n0": ((1e-7) ** 3), "p0": ((1e-7) ** 3),
                             "mu_n": ((1e7) ** 2) / (1e9),

--- a/GUI/quicksim.py
+++ b/GUI/quicksim.py
@@ -59,8 +59,8 @@ class QuicksimManager():
             if chain.visible.get() == 0: # Don't simulate disabled chains
                 continue
             param_info = {}
-            param_info["names"] = [x for x in self.window.data[chain.fname] if x not in self.window.sp.func]
-            param_info["init_guess"] = {x: self.window.data[chain.fname][x][-1] for x in param_info["names"]}
+            param_info["names"] = [x for x in chain.data if x not in self.window.sp.func]
+            param_info["init_guess"] = {x: chain.data[x][-1] for x in param_info["names"]}
             param_info["active"] = {x: True for x in param_info["names"]}
             param_info["unit_conversions"] = {"n0": ((1e-7) ** 3), "p0": ((1e-7) ** 3),
                             "mu_n": ((1e7) ** 2) / (1e9),

--- a/GUI/quicksim_result_popup.py
+++ b/GUI/quicksim_result_popup.py
@@ -117,7 +117,12 @@ class QuicksimResultPopup(Popup):
         """Fill in s_frame with scale factors for each chain's final state"""
         for i in range(self.n_sims):
             for c in range(self.n_chains):
-                scale_f = self.window.data[self.active_chain_names[c]]
+                # TODO: Make QSR not rely on indexing by fnames anymore
+                scale_f = {}
+                for chain in self.window.chains:
+                    if chain.fname == self.active_chain_names[c]:
+                        scale_f = chain.data
+
                 if f"_s{i}" in scale_f:
                     scale_f = scale_f[f"_s{i}"][-1]
                 else:

--- a/GUI/secondary_parameters.py
+++ b/GUI/secondary_parameters.py
@@ -47,22 +47,19 @@ class SecondaryParameters():
         # Most recent thickness used to calculate; determines if recalculation needed when thickness updated
         self.last_thickness = {name: -1 for name in self.func if "thickness" in self.func[name][1]}
 
-    def get(self, data, data_keys, thickness : str) -> None:
+    def get(self, data, value, thickness : str) -> None:
         """
         Calculate and cache the requested secondary parameter from a Data object provided by GUI
 
         Parameters
         ----------
-        data : Data
-            Object containing MCMC results loaded from a .pik file produced by metropolis()
-        data_keys : dict[str, str | bool]
-            Dict of two necessary indices for data - file_name that the result came from,
-            and value to calculate
+        data : dict[str, np.ndarray]
+            Dict containing MCMC results for each parameter in a chain, as defined in Chain()
+        value : str
+            Name of desired secondary parameter to calculate
         thickness : str
             Thickness string from GUI, needed for some diffusion lifetimes.
         """
-        file_name = data_keys["file_name"]
-        value = data_keys["value"]
         primary_params = {}
         for needed_param in self.func[value][1]:
             if needed_param == "thickness": # Not included in MCMC data
@@ -72,13 +69,13 @@ class SecondaryParameters():
                     raise ValueError("Thickness value needed") from err
             else:
                 try:
-                    primary_params[needed_param] = data[file_name][needed_param]
+                    primary_params[needed_param] = data[needed_param]
                 except KeyError as err:
-                    raise KeyError(f"Data {file_name} missing parameter {needed_param}") from err
+                    raise KeyError(f"Missing parameter {needed_param}") from err
 
         try:
             y = self.func[value][0](primary_params)
-            data[file_name][value] = np.array(y)
+            data[value] = np.array(y)
         except KeyError as err:
             raise KeyError(f"Failed to calculate {value}") from err
 

--- a/GUI/window.py
+++ b/GUI/window.py
@@ -35,6 +35,13 @@ ACC_BIN_SIZE = 100
 DEFAULT_THICKNESS = 2000
 MAX_STATUS_MSGS = 11
 
+class TracedIntVar(tk.IntVar):
+    """ Extension of tkinter IntVar - records ID of its trace function"""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.trace_id = -1
+
 class Window(TkGUI):
     """ The main GUI object"""
     qsr_popup: QuicksimResultPopup
@@ -51,7 +58,7 @@ class Window(TkGUI):
         self.data = dict[str, dict[str, np.ndarray]]()
 
         # List of loaded MCMC chains, and whether they are active
-        self.file_names = dict[str, tk.IntVar]()
+        self.file_names = dict[str, TracedIntVar]()
 
         # List of additional variables needed for simulations
         self.ext_variables = ["thickness", "nx", "final_time", "nt",
@@ -275,9 +282,9 @@ class Window(TkGUI):
                 self.status(f"Error: {err}")
                 continue
 
-        self.file_names = {file_name: tk.IntVar(value=1) for file_name in file_names}
+        self.file_names = {file_name: TracedIntVar(value=1) for file_name in file_names}
         for file_name in self.file_names:
-            self.file_names[file_name].trace("w", self.on_active_chain_update)
+            self.file_names[file_name].trace_id = self.file_names[file_name].trace("w", self.on_active_chain_update)
 
         # Generate a button for each parameter
         self.mini_panel.widgets["chart menu"].configure(state=tk.NORMAL) # type: ignore

--- a/GUI/window.py
+++ b/GUI/window.py
@@ -151,12 +151,9 @@ class Window(TkGUI):
 
     def do_quicksim_result_popup(self, n_chains, n_sims) -> None:
         """Show quicksim results"""
-        active_chain_names = []
-        for chain in self.chains:
-            if chain.visible.get() != 0:
-                active_chain_names.append(chain.fname)
+        active_chain_inds = [i for i in range(len(self.chains)) if self.chains[i].visible.get()]
         self.qsr_popup = QuicksimResultPopup(self, self.side_panel.widget, n_chains, n_sims,
-                                             active_chain_names)
+                                             active_chain_inds)
 
     def query_quicksim(self, expected_num_sims : int) -> None:
         """Periodically check and plot completed quicksims"""


### PR DESCRIPTION
Fix issue where vertical size of the chain visibility popup was scaling beyond the maximum number of chains per column

Replace "self.file_names," which, confusingly, referred to whether each chain was visible on plots, with a list of Chain objects each with visibility attributes